### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -8,7 +8,7 @@ require 'scraperwiki'
 
 require_relative 'lib/politician'
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 house = EveryPolitician::Index.new.country('Sweden').lower_house
 house.popolo.persons.map(&:wikidata).compact.each_slice(100) do |wanted|
   data = Wikisnakker::Politician.find(wanted).flat_map(&:positions).compact


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593